### PR TITLE
fix: version badges / database badge

### DIFF
--- a/src/Host/mate.WebUI/Components/Pages/Help.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Help.razor
@@ -80,6 +80,21 @@
                     }
                 </div>
                 <div class="d-flex justify-content-between align-items-center pb-2 border-bottom">
+                    <span class="text-muted"><i class="bi bi-database me-1"></i>Database Mode</span>
+                    @if (string.Equals(_databaseMode, "PostgreSQL", StringComparison.OrdinalIgnoreCase))
+                    {
+                        <span class="badge badge-pass"><i class="bi bi-server me-1"></i>PostgreSQL</span>
+                    }
+                    else if (string.Equals(_databaseMode, "SQLite", StringComparison.OrdinalIgnoreCase))
+                    {
+                        <span class="badge badge-info"><i class="bi bi-hdd-stack me-1"></i>SQLite</span>
+                    }
+                    else
+                    {
+                        <span class="badge badge-neutral">@_databaseMode</span>
+                    }
+                </div>
+                <div class="d-flex justify-content-between align-items-center pb-2 border-bottom">
                     <span class="text-muted"><i class="bi bi-shield-lock me-1"></i>Authentication</span>
                     @if (_authEnabled)
                     {
@@ -182,13 +197,14 @@
     private bool   _inContainer;
     private bool   _authEnabled;
     private string _authScheme     = "";
+    private string _databaseMode   = "Unknown";
     private bool   _forwardedHeaders;
 
     protected override void OnInitialized()
     {
         var versionFile = Path.Combine(AppContext.BaseDirectory, "VERSION");
         if (File.Exists(versionFile))
-            _appVersion = File.ReadAllText(versionFile).Trim();
+            _appVersion = NormalizeVersion(File.ReadAllText(versionFile).Trim());
 
         _inContainer = string.Equals(
             Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true",
@@ -197,9 +213,22 @@
         _authScheme  = Configuration["Authentication:Scheme"] ?? "None";
         _authEnabled = string.Equals(_authScheme, "EntraId", StringComparison.OrdinalIgnoreCase);
 
+        var providerName = Db.Database.ProviderName ?? string.Empty;
+        _databaseMode = providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase)
+            ? "PostgreSQL"
+            : providerName.Contains("Sqlite", StringComparison.OrdinalIgnoreCase)
+                ? "SQLite"
+                : (string.IsNullOrWhiteSpace(providerName) ? "Unknown" : providerName);
+
         _forwardedHeaders = string.Equals(
             Environment.GetEnvironmentVariable("ASPNETCORE_FORWARDEDHEADERS_ENABLED"), "true",
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version)) return string.Empty;
+        return version.Trim().TrimStart('v', 'V');
     }
 
     private async Task RunHealthCheck()

--- a/src/Host/mate.WebUI/Components/Pages/Home.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Home.razor
@@ -323,7 +323,7 @@ else
         if (!File.Exists(versionFile))
             versionFile = Path.Combine(Directory.GetCurrentDirectory(), "VERSION");
         if (File.Exists(versionFile))
-            _version = (await File.ReadAllTextAsync(versionFile)).Trim();
+            _version = NormalizeVersion((await File.ReadAllTextAsync(versionFile)).Trim());
 
         var changelogFile = Path.Combine(HostEnv.ContentRootPath, "CHANGELOG.md");
         if (!File.Exists(changelogFile))
@@ -361,6 +361,12 @@ else
         _qgenModules      = Registry.GetAllQuestionProviders().ToList();
 
         _loading = false;
+    }
+
+    private static string NormalizeVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version)) return string.Empty;
+        return version.Trim().TrimStart('v', 'V');
     }
 
     private async Task OpenQuickRun()


### PR DESCRIPTION
1. chore(ui): normalize displayed app version by removing leading v/V
 - strip prefix from version read from VERSION before rendering
- apply consistently on Home and Help version badges
3. feat(help): show runtime database mode badge
- add Database Mode row under Runtime Environment
- detect EF provider and render PostgreSQL or SQLite badge (fallback to provider name)