### PR TITLE
style(webui): fix dark-mode contrast and tokenise all inline styles

### DIFF
--- a/src/Host/mate.WebUI/Components/Pages/Agents.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Agents.razor
@@ -132,7 +132,7 @@ else
                                      style="cursor:pointer;transition:all 0.2s;@(isSelected ? "border-color:var(--primary);box-shadow:0 0 0 2px rgba(0,102,204,0.2)" : "")"
                                      @onclick="() => SelectConnectorType(module.ConnectorType)">
                                     <div class="d-flex align-items-center gap-3">
-                                        <div style="width:40px;height:40px;border-radius:10px;background:linear-gradient(135deg,#0066cc20,#8b5cf620);display:flex;align-items:center;justify-content:center;">
+                                        <div class="icon-tile icon-tile-primary-soft">
                                             <i class="bi bi-robot" style="color:var(--primary)"></i>
                                         </div>
                                         <div>

--- a/src/Host/mate.WebUI/Components/Pages/Help.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Help.razor
@@ -17,7 +17,7 @@
     <p>Source, author info, runtime environment and API reference for @BrandInfo.BrandName
         @if (!string.IsNullOrEmpty(_appVersion))
         {
-            <span class="badge ms-2" style="background:var(--primary,#0066cc);color:#fff;font-size:11px;font-weight:600;padding:2px 10px;border-radius:10px;vertical-align:middle">@_appVersion</span>
+            <span class="badge ms-2" style="background:var(--primary);color:#fff;font-size:11px;font-weight:600;padding:2px 10px;border-radius:10px;vertical-align:middle">@_appVersion</span>
         }
     </p>
 
@@ -26,7 +26,7 @@
     <!-- Source & Documentation -->
     <div class="col-md-4">
         <div class="section-card h-100 d-flex flex-column">
-            <div style="width:48px;height:48px;background:linear-gradient(135deg,#24292e,#1a1e22);border-radius:12px;margin-bottom:16px;display:flex;align-items:center;justify-content:center;color:#fff;flex-shrink:0">
+            <div class="icon-tile-lg icon-tile-github">
                 <i class="bi bi-github" style="font-size:24px"></i>
             </div>
             <h2 class="section-title">Source &amp; Documentation</h2>
@@ -41,7 +41,7 @@
     <!-- About the Author -->
     <div class="col-md-4">
         <div class="section-card h-100 d-flex flex-column">
-            <div style="width:48px;height:48px;background:linear-gradient(135deg,#0066cc,#003d99);border-radius:12px;margin-bottom:16px;display:flex;align-items:center;justify-content:center;color:#fff;flex-shrink:0">
+            <div class="icon-tile-lg icon-tile-primary">
                 <i class="bi bi-person-circle" style="font-size:24px"></i>
             </div>
             <h2 class="section-title">About the Author</h2>
@@ -56,7 +56,7 @@
     <!-- Runtime Environment -->
     <div class="col-md-4">
         <div class="section-card h-100">
-            <div style="width:48px;height:48px;background:linear-gradient(135deg,#37474f,#1c2529);border-radius:12px;margin-bottom:16px;display:flex;align-items:center;justify-content:center;color:#fff">
+            <div class="icon-tile-lg icon-tile-neutral-dark">
                 <i class="bi bi-server" style="font-size:24px"></i>
             </div>
             <h2 class="section-title">Runtime Environment</h2>
@@ -157,15 +157,15 @@
                 <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px">
                     @foreach (var check in _healthChecks)
                     {
-                        <div class="kpi-card" style="border-left:4px solid @(check.Ok ? "#28a745" : "#dc3545");text-align:left;min-height:90px">
+                        <div class="kpi-card" style="border-left:4px solid @(check.Ok ? "var(--success)" : "var(--danger)");text-align:left;min-height:90px">
                             <div style="font-size:1rem;margin-bottom:4px">
                                 @if (check.Ok)
                                 {
-                                    <i class="bi bi-check-circle-fill" style="color:#28a745"></i>
+                                    <i class="bi bi-check-circle-fill" style="color:var(--success)"></i>
                                 }
                                 else
                                 {
-                                    <i class="bi bi-x-circle-fill" style="color:#dc3545"></i>
+                                    <i class="bi bi-x-circle-fill" style="color:var(--danger)"></i>
                                 }
                                 <strong style="margin-left:6px;font-size:13px">@check.Name</strong>
                             </div>

--- a/src/Host/mate.WebUI/Components/Pages/Home.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Home.razor
@@ -41,32 +41,32 @@ else
     <!-- Action cards -->
     <div class="home-action-grid mb-4">
         <div class="home-action-card" @onclick='() => Navigation.NavigateTo("/wizard")'>
-            <div class="home-action-icon" style="background:linear-gradient(135deg,#f59e0b,#d97706)"><i class="bi bi-magic"></i></div>
+            <div class="home-action-icon icon-tile-warning"><i class="bi bi-magic"></i></div>
             <div class="fw-600">Setup Wizard</div>
             <div class="text-muted" style="font-size:12px">Guided setup</div>
         </div>
         <div class="home-action-card" @onclick='() => Navigation.NavigateTo("/test-suites")'>
-            <div class="home-action-icon" style="background:linear-gradient(135deg,#0066cc,#003d99)"><i class="bi bi-list-check"></i></div>
+            <div class="home-action-icon icon-tile-primary"><i class="bi bi-list-check"></i></div>
             <div class="fw-600">Test Suites</div>
             <div class="text-muted" style="font-size:12px">Manage &amp; run</div>
         </div>
         <div class="home-action-card" @onclick='() => Navigation.NavigateTo("/documents")'>
-            <div class="home-action-icon" style="background:linear-gradient(135deg,#8b5cf6,#6d28d9)"><i class="bi bi-file-earmark-text"></i></div>
+            <div class="home-action-icon icon-tile-secondary"><i class="bi bi-file-earmark-text"></i></div>
             <div class="fw-600">Documents</div>
             <div class="text-muted" style="font-size:12px">Upload &amp; manage</div>
         </div>
         <div class="home-action-card" @onclick='() => Navigation.NavigateTo("/agents")'>
-            <div class="home-action-icon" style="background:linear-gradient(135deg,#06b6d4,#0891b2)"><i class="bi bi-robot"></i></div>
+            <div class="home-action-icon icon-tile-info"><i class="bi bi-robot"></i></div>
             <div class="fw-600">Agents</div>
             <div class="text-muted" style="font-size:12px">Configure connectors</div>
         </div>
         <div class="home-action-card" @onclick='() => Navigation.NavigateTo("/dashboard")'>
-            <div class="home-action-icon" style="background:linear-gradient(135deg,#10b981,#047857)"><i class="bi bi-graph-up"></i></div>
+            <div class="home-action-icon icon-tile-success"><i class="bi bi-graph-up"></i></div>
             <div class="fw-600">Dashboard</div>
             <div class="text-muted" style="font-size:12px">KPIs &amp; history</div>
         </div>
         <div class="home-action-card" @onclick="OpenQuickRun">
-            <div class="home-action-icon" style="background:linear-gradient(135deg,#ef4444,#b91c1c)"><i class="bi bi-play-fill"></i></div>
+            <div class="home-action-icon icon-tile-danger"><i class="bi bi-play-fill"></i></div>
             <div class="fw-600">Quick Run</div>
             <div class="text-muted" style="font-size:12px">Run suite now</div>
         </div>
@@ -193,8 +193,8 @@ else
             <div class="row g-3">
                 <div class="col-md-3">
                     <div class="d-flex gap-3">
-                        <div style="width:32px;height:32px;background:#e6f0ff;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                            <span style="font-size:14px;font-weight:700;color:#0066cc">1</span>
+                        <div style="width:32px;height:32px;background:rgba(0,102,204,0.12);border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                            <span style="font-size:14px;font-weight:700;color:var(--primary)">1</span>
                         </div>
                         <div>
                             <div style="font-size:13px;font-weight:600">Configure Settings</div>
@@ -204,8 +204,8 @@ else
                 </div>
                 <div class="col-md-3">
                     <div class="d-flex gap-3">
-                        <div style="width:32px;height:32px;background:#f3e8ff;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                            <span style="font-size:14px;font-weight:700;color:#8b5cf6">2</span>
+                        <div style="width:32px;height:32px;background:rgba(139,92,246,0.12);border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                            <span style="font-size:14px;font-weight:700;color:var(--secondary)">2</span>
                         </div>
                         <div>
                             <div style="font-size:13px;font-weight:600">Register an Agent</div>
@@ -215,8 +215,8 @@ else
                 </div>
                 <div class="col-md-3">
                     <div class="d-flex gap-3">
-                        <div style="width:32px;height:32px;background:#d1fae5;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                            <span style="font-size:14px;font-weight:700;color:#059669">3</span>
+                        <div style="width:32px;height:32px;background:rgba(16,185,129,0.12);border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                            <span style="font-size:14px;font-weight:700;color:var(--success)">3</span>
                         </div>
                         <div>
                             <div style="font-size:13px;font-weight:600">Create a Test Suite</div>
@@ -226,8 +226,8 @@ else
                 </div>
                 <div class="col-md-3">
                     <div class="d-flex gap-3">
-                        <div style="width:32px;height:32px;background:#fff7ed;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                            <span style="font-size:14px;font-weight:700;color:#ea580c">4</span>
+                        <div style="width:32px;height:32px;background:rgba(234,88,12,0.12);border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                            <span style="font-size:14px;font-weight:700;color:var(--warning)">4</span>
                         </div>
                         <div>
                             <div style="font-size:13px;font-weight:600">Run &amp; Evaluate</div>
@@ -248,7 +248,7 @@ else
 {
     <div class="modal-backdrop" @onclick="CloseQuickRun">
         <div class="modal-box" @onclick:stopPropagation style="width:460px">
-            <h2><i class="bi bi-play-fill me-2" style="color:#10b981"></i>Quick Run</h2>
+            <h2><i class="bi bi-play-fill me-2" style="color:var(--success)"></i>Quick Run</h2>
             @if (!string.IsNullOrEmpty(_quickRunMsg))
             {
                 <div class="alert @(_quickRunSuccess ? "alert-success" : "alert-danger") mb-3" style="font-size:13px">@_quickRunMsg</div>

--- a/src/Host/mate.WebUI/Components/Pages/RunReport.razor
+++ b/src/Host/mate.WebUI/Components/Pages/RunReport.razor
@@ -312,7 +312,7 @@ else
                                 <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:14px">
                                     @if (r.TestCase?.UserInput?.Length > 0)
                                     {
-                                        <div style="background:white;padding:12px;border-radius:6px;border-left:3px solid var(--primary)">
+                                        <div class="report-callout" style="border-left-color:var(--primary)">
                                             <div style="font-size:11px;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.4px;margin-bottom:4px">User Input</div>
                                             <div style="font-size:13px;color:var(--text-primary);line-height:1.5">@string.Join(" → ", r.TestCase.UserInput.Take(3))@(r.TestCase.UserInput.Length > 3 ? "…" : "")</div>
                                         </div>
@@ -320,14 +320,14 @@ else
                                     @if (!string.IsNullOrWhiteSpace(r.TestCase?.ReferenceAnswer) || !string.IsNullOrWhiteSpace(r.TestCase?.AcceptanceCriteria))
                                     {
                                         var _exp = r.TestCase?.ReferenceAnswer ?? r.TestCase?.AcceptanceCriteria ?? "";
-                                        <div style="background:white;padding:12px;border-radius:6px;border-left:3px solid var(--success)">
+                                        <div class="report-callout" style="border-left-color:var(--success)">
                                             <div style="font-size:11px;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.4px;margin-bottom:4px">Expected</div>
                                             <div style="font-size:13px;color:var(--text-primary);line-height:1.5">@(_exp.Length > 250 ? _exp[..248] + "…" : _exp)</div>
                                         </div>
                                     }
                                     @if (!string.IsNullOrWhiteSpace(r.Rationale))
                                     {
-                                        <div style="background:white;padding:12px;border-radius:6px;border-left:3px solid var(--warning)">
+                                        <div class="report-callout" style="border-left-color:var(--warning)">
                                             <div style="font-size:11px;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.4px;margin-bottom:4px">Judge Rationale</div>
                                             <div style="font-size:13px;color:var(--text-primary);line-height:1.5">@r.Rationale</div>
                                         </div>
@@ -353,8 +353,8 @@ else
                                 @if (_scoreHistory.TryGetValue(r.TestCaseId, out var _hist) && _hist.Count >= 2)
                                 {
                                     var _delta = _hist.Last() - _hist.First();
-                                    <div style="font-size:12px;color:var(--text-secondary);display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 12px;background:white;border-radius:6px;border-left:3px solid #8b5cf6">
-                                        <span style="font-weight:600;color:#6d28d9">Score history (@_hist.Count runs):</span>
+                                    <div class="report-callout" style="font-size:12px;color:var(--text-secondary);display:flex;align-items:center;gap:8px;flex-wrap:wrap;border-left-color:var(--secondary);padding:8px 12px">
+                                        <span style="font-weight:600;color:var(--secondary)">Score history (@_hist.Count runs):</span>
                                         <div style="display:flex;gap:3px;align-items:center">
                                             @foreach (var _s in _hist)
                                             {

--- a/src/Host/mate.WebUI/Components/Pages/Settings.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Settings.razor
@@ -52,7 +52,7 @@
                 <div class="col-md-6 col-lg-4">
                     <div class="section-card h-100">
                         <div class="d-flex align-items-center gap-3 mb-3">
-                            <div style="width:42px;height:42px;border-radius:10px;background:linear-gradient(135deg,#0066cc20,#8b5cf620);display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                            <div class="icon-tile-md icon-tile-primary-soft">
                                 <i class="bi @ConnectorIcon(m.ConnectorType)" style="color:var(--primary);font-size:18px"></i>
                             </div>
                             <div>
@@ -99,7 +99,7 @@
                 <div class="col-md-6 col-lg-4">
                     <div class="section-card h-100">
                         <div class="d-flex align-items-center gap-3 mb-3">
-                            <div style="width:42px;height:42px;border-radius:10px;background:linear-gradient(135deg,#16a34a20,#0066cc20);display:flex;align-items:center;justify-content:center;flex-shrink:0">
+                            <div class="icon-tile-md icon-tile-success-soft">
                                 <i class="bi bi-award" style="color:var(--success);font-size:18px"></i>
                             </div>
                             <div>
@@ -142,8 +142,8 @@
                 <div class="col-md-6 col-lg-4">
                     <div class="section-card">
                         <div class="d-flex align-items-center gap-3">
-                            <div style="width:42px;height:42px;border-radius:10px;background:linear-gradient(135deg,#f59e0b20,#0066cc20);display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                                <i class="bi bi-activity" style="color:#f59e0b;font-size:18px"></i>
+                            <div class="icon-tile-md icon-tile-warning-soft">
+                                <i class="bi bi-activity" style="color:var(--warning);font-size:18px"></i>
                             </div>
                             <div>
                                 <div style="font-weight:600">@m.DisplayName</div>
@@ -170,8 +170,8 @@
                 <div class="col-md-6 col-lg-4">
                     <div class="section-card h-100">
                         <div class="d-flex align-items-center gap-3 mb-3">
-                            <div style="width:42px;height:42px;border-radius:10px;background:linear-gradient(135deg,#20c99720,#0066cc20);display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                                <i class="bi bi-stars" style="color:#20c997;font-size:18px"></i>
+                            <div class="icon-tile-md icon-tile-teal-soft">
+                                <i class="bi bi-stars" style="color:var(--success);font-size:18px"></i>
                             </div>
                             <div>
                                 <div style="font-weight:600">@QGenDisplayName(m.ProviderType)</div>
@@ -201,8 +201,8 @@
                 <div class="col-md-6 col-lg-4">
                     <div class="section-card h-100">
                         <div class="d-flex align-items-center gap-3 mb-3">
-                            <div style="width:42px;height:42px;border-radius:10px;background:linear-gradient(135deg,#dc262620,#7c3aed20);display:flex;align-items:center;justify-content:center;flex-shrink:0">
-                                <i class="bi bi-shield-exclamation" style="color:#dc2626;font-size:18px"></i>
+                            <div class="icon-tile-md icon-tile-danger-soft">
+                                <i class="bi bi-shield-exclamation" style="color:var(--danger);font-size:18px"></i>
                             </div>
                             <div>
                                 <div style="font-weight:600">@m.DisplayName</div>
@@ -1035,7 +1035,7 @@
             <span class="section-title">Authentication</span>
             @if (_authScheme is "None" or "Generic")
             {
-                <span class="connector-badge" style="background:#e65100">Development Mode</span>
+                <span class="connector-badge" style="background:var(--warning);color:#fff">Development Mode</span>
             }
             else if (_authScheme is "EntraId" or "OAuth")
             {

--- a/src/Host/mate.WebUI/Components/Pages/TestSuites.razor
+++ b/src/Host/mate.WebUI/Components/Pages/TestSuites.razor
@@ -78,7 +78,7 @@
                             @if (_expandedSuiteId == suite.Id)
                             {
                                 <tr>
-                                    <td colspan="5" style="padding:0 1rem 1rem;background:var(--bg-page,#f5f7fa)">
+                                    <td colspan="5" style="padding:0 1rem 1rem;background:var(--surface-2);color:var(--text-primary)">
                                         <div class="section-header" style="margin-top:12px;margin-bottom:8px">
                                             <strong>Test Cases</strong>
                                             <button class="btn btn-sm btn-primary" @onclick="() => OpenAddCase(suite)">
@@ -187,13 +187,13 @@ else if (_showSuiteForm)
         </div>
 
         <div class="section-card">
-            <h2 class="section-title mb-3" style="color:#6f42c1"><i class="bi bi-award me-2"></i>Judge Configuration</h2>
+            <h2 class="section-title mb-3" style="color:var(--secondary)"><i class="bi bi-award me-2"></i>Judge Configuration</h2>
             @{
                 var defaultJudge = _judgeSettings.FirstOrDefault(j => j.IsDefault);
             }
             @if (defaultJudge is not null)
             {
-                <div style="background:#f5f0ff;padding:10px 14px;border-radius:6px;border-left:4px solid #6f42c1;font-size:13px;margin-bottom:16px">
+                <div style="background:rgba(139,92,246,0.08);padding:10px 14px;border-radius:6px;border-left:4px solid var(--secondary);font-size:13px;margin-bottom:16px">
                     <strong>System default:</strong> @defaultJudge.Name (@defaultJudge.ProviderType) — threshold @defaultJudge.PassThreshold.ToString("P0")
                 </div>
             }
@@ -213,7 +213,7 @@ else if (_showSuiteForm)
             }
             @if (selJudge is not null)
             {
-                <div style="background:#f8f9fa;padding:12px;border-radius:8px;border-left:4px solid #6f42c1;font-size:13px;margin-top:8px">
+                <div style="background:var(--surface-2);padding:12px;border-radius:8px;border-left:4px solid var(--secondary);font-size:13px;margin-top:8px">
                     <div class="mb-1"><strong>Provider:</strong> @selJudge.ProviderType</div>
                     <div class="mb-1"><strong>Pass Threshold:</strong> @selJudge.PassThreshold.ToString("P0")</div>
                     <div class="mb-1"><strong>Weights:</strong> Task @selJudge.TaskSuccessWeight.ToString("P0") · Intent @selJudge.IntentMatchWeight.ToString("P0") · Factuality @selJudge.FactualityWeight.ToString("P0") · Helpfulness @selJudge.HelpfulnessWeight.ToString("P0") · Safety @selJudge.SafetyWeight.ToString("P0")</div>
@@ -234,10 +234,10 @@ else if (_showSuiteForm)
         </div>
 
         <div class="section-card">
-            <h2 class="section-title mb-3" style="color:#20c997"><i class="bi bi-stars me-2"></i>AI Question Generation</h2>
+            <h2 class="section-title mb-3" style="color:var(--success)"><i class="bi bi-stars me-2"></i>AI Question Generation</h2>
             @if (_qgenSetting is not null)
             {
-                <div style="background:#f0fdf4;padding:10px 14px;border-radius:6px;border-left:4px solid #20c997;font-size:13px;margin-bottom:16px">
+                <div style="background:rgba(32,201,151,0.08);padding:10px 14px;border-radius:6px;border-left:4px solid var(--success);font-size:13px;margin-bottom:16px">
                     <strong>System default:</strong> @_qgenSetting.Model
                     @if (!string.IsNullOrWhiteSpace(_qgenSetting.SystemPrompt))
                     {

--- a/src/Host/mate.WebUI/Components/Pages/Wizard.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Wizard.razor
@@ -65,7 +65,7 @@
                          style="cursor:pointer;transition:all 0.2s;@(isSelected ? "border-color:var(--primary);box-shadow:0 0 0 2px rgba(0,102,204,0.2)" : "")"
                          @onclick="() => _selectedConnectorType = module.ConnectorType">
                         <div class="d-flex align-items-center gap-3">
-                            <div style="width:40px;height:40px;border-radius:10px;background:linear-gradient(135deg,#0066cc20,#8b5cf620);display:flex;align-items:center;justify-content:center;">
+                            <div class="icon-tile icon-tile-primary-soft">
                                 <i class="bi bi-robot" style="color:var(--primary)"></i>
                             </div>
                             <div>

--- a/src/Host/mate.WebUI/wwwroot/app.css
+++ b/src/Host/mate.WebUI/wwwroot/app.css
@@ -49,12 +49,23 @@ h1:focus, h2:focus, h3:focus, h4:focus, h5:focus, h6:focus {
     --text-tertiary:  #78787f;
     --text-muted:     #9ca3af;
     --surface-2:      #2c2d32;
+    color-scheme: dark;
 }
 
 [data-theme="dark"] body {
     background-color: var(--light-bg);
     color: var(--text-primary);
 }
+
+[data-theme="dark"] a { color: var(--primary); }
+
+[data-theme="dark"] .text-muted,
+[data-theme="dark"] .text-body-secondary,
+[data-theme="dark"] .text-secondary,
+[data-theme="dark"] .text-body,
+[data-theme="dark"] .text-black-50 { color: var(--text-muted) !important; }
+
+[data-theme="dark"] .form-check-label { color: var(--text-primary); }
 
 [data-theme="dark"] .mate-sidebar {
     background: var(--card-bg);
@@ -82,22 +93,73 @@ h1:focus, h2:focus, h3:focus, h4:focus, h5:focus, h6:focus {
 
 [data-theme="dark"] .form-control { background: #1e1f22; color: var(--text-primary); border-color: var(--border); }
 
+[data-theme="dark"] .form-control::placeholder,
+[data-theme="dark"] .filter-input::placeholder { color: var(--text-tertiary); opacity: 1; }
+
 [data-theme="dark"] .form-control:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(77,159,255,0.15); }
 
-[data-theme="dark"] select option { background: #25262b; }
+/* Browser autofill injects its own background overlay — override it so text stays readable */
+[data-theme="dark"] input:-webkit-autofill,
+[data-theme="dark"] input:-webkit-autofill:hover,
+[data-theme="dark"] input:-webkit-autofill:focus,
+[data-theme="dark"] textarea:-webkit-autofill,
+[data-theme="dark"] textarea:-webkit-autofill:hover,
+[data-theme="dark"] textarea:-webkit-autofill:focus {
+    -webkit-text-fill-color: var(--text-primary);
+    -webkit-box-shadow: 0 0 0 1000px #1e1f22 inset;
+    transition: background-color 5000s ease-in-out 0s;
+    caret-color: var(--text-primary);
+}
+
+[data-theme="dark"] select option { background: #25262b; color: var(--text-primary); }
+
+[data-theme="dark"] .form-check-input {
+    background-color: #1e1f22;
+    border-color: #5c616b;
+}
+
+[data-theme="dark"] .form-check-input:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(77,159,255,0.15);
+}
+
+[data-theme="dark"] .form-check-input:checked {
+    background-color: var(--primary);
+    border-color: var(--primary);
+}
+
+[data-theme="dark"] .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+    opacity: 0.85;
+}
+
+[data-theme="dark"] .btn-close:hover { opacity: 1; }
+
+[data-theme="dark"] .btn-close:focus { box-shadow: 0 0 0 3px rgba(77,159,255,0.15); }
 
 [data-theme="dark"] .btn-secondary { background: #373a40; color: var(--text-primary); border-color: var(--border); }
 [data-theme="dark"] .btn-secondary:hover { background: #4a4d55; }
 
 [data-theme="dark"] .filter-input, [data-theme="dark"] .filter-select { background: #1e1f22; color: var(--text-primary); }
 
-[data-theme="dark"] .modal-box { background: var(--card-bg); }
+[data-theme="dark"] .modal-box { background: var(--card-bg); color: var(--text-primary); border: 1px solid var(--border); }
 
 [data-theme="dark"] .transcript-bubble.bot { background: #2c2d32; border-color: var(--border); }
 
 [data-theme="dark"] .kpi-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
 
 [data-theme="dark"] .home-action-card:hover { box-shadow: 0 6px 16px rgba(0,0,0,0.4); }
+
+/* Explicitly set text color on card surfaces so Bootstrap's --bs-body-color (#212529)
+    cannot leak through when data-bs-theme is not set */
+[data-theme="dark"] .section-card,
+[data-theme="dark"] .kpi-card,
+[data-theme="dark"] .mate-header,
+[data-theme="dark"] .mate-page { color: var(--text-primary); }
+
+/* Bootstrap spinner uses currentcolor — ensure it's light in dark mode */
+[data-theme="dark"] .spinner-border { color: var(--text-primary); }
+[data-theme="dark"] .btn-primary .spinner-border { color: #fff; }
 
 /* Badge text colours in dark mode — use semantic CSS vars for legibility */
 [data-theme="dark"] .badge-pass,
@@ -109,7 +171,8 @@ h1:focus, h2:focus, h3:focus, h4:focus, h5:focus, h6:focus {
 [data-theme="dark"] .badge-unhealthy    { color: var(--danger); }
 [data-theme="dark"] .badge-running      { color: var(--info); }
 [data-theme="dark"] .badge-pending,
-[data-theme="dark"] .badge-skip         { color: var(--accent); }
+[data-theme="dark"] .badge-skip,
+[data-theme="dark"] .badge-skipped      { color: var(--accent); }
 [data-theme="dark"] .badge-purple       { color: var(--secondary); }
 [data-theme="dark"] .badge-premium      { color: var(--accent); }
 /* Alert text + border in dark mode */
@@ -122,6 +185,7 @@ h1:focus, h2:focus, h3:focus, h4:focus, h5:focus, h6:focus {
 /* Bootstrap border utilities — follow our theme border colour */
 [data-theme="dark"] .border-bottom { border-bottom-color: var(--border) !important; }
 [data-theme="dark"] .border-top    { border-top-color:    var(--border) !important; }
+[data-theme="dark"] .border-primary { border-color: rgba(77,159,255,0.5) !important; }
 
 /* ── Reset & Base ──────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
@@ -466,6 +530,27 @@ html, body {
     font-size: 24px; color: white;
 }
 
+/* ── Icon tile utility classes ────────────────────────────── */
+/* Base layouts */
+.icon-tile    { width: 40px; height: 40px; border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.icon-tile-md { width: 42px; height: 42px; border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.icon-tile-lg { width: 48px; height: 48px; border-radius: 12px; margin-bottom: 16px; display: flex; align-items: center; justify-content: center; color: #fff; flex-shrink: 0; }
+/* Solid gradients */
+.icon-tile-warning      { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.icon-tile-primary      { background: linear-gradient(135deg, #0066cc, #003d99); }
+.icon-tile-secondary    { background: linear-gradient(135deg, #8b5cf6, #6d28d9); }
+.icon-tile-info         { background: linear-gradient(135deg, #06b6d4, #0891b2); }
+.icon-tile-success      { background: linear-gradient(135deg, #10b981, #047857); }
+.icon-tile-danger       { background: linear-gradient(135deg, #ef4444, #b91c1c); }
+.icon-tile-github       { background: linear-gradient(135deg, #2d333b, #555f6b); }
+.icon-tile-neutral-dark { background: linear-gradient(135deg, #37474f, #1c2529); }
+/* Soft (translucent) gradients */
+.icon-tile-primary-soft { background: linear-gradient(135deg, rgba(0,102,204,0.12), rgba(139,92,246,0.12)); }
+.icon-tile-success-soft { background: linear-gradient(135deg, rgba(22,163,74,0.12), rgba(0,102,204,0.12)); }
+.icon-tile-warning-soft { background: linear-gradient(135deg, rgba(245,158,11,0.12), rgba(0,102,204,0.12)); }
+.icon-tile-teal-soft    { background: linear-gradient(135deg, rgba(32,201,151,0.12), rgba(0,102,204,0.12)); }
+.icon-tile-danger-soft  { background: linear-gradient(135deg, rgba(220,38,38,0.12), rgba(124,58,237,0.12)); }
+
 /* ── Section Card ──────────────────────────────────────────── */
 .section-card {
     background: var(--card-bg);
@@ -567,7 +652,7 @@ html, body {
 }
 .badge-pass, .badge-completed, .badge-healthy        { background: rgba(16,185,129,0.12); color: #059669; }
 .badge-fail, .badge-failed, .badge-error, .badge-unhealthy { background: rgba(239,68,68,0.12);  color: #dc2626; }
-.badge-pending, .badge-skip                          { background: rgba(245,158,11,0.12); color: #b45309; }
+.badge-pending, .badge-skip, .badge-skipped           { background: rgba(245,158,11,0.12); color: #b45309; }
 .badge-running                                       { background: rgba(59,130,246,0.12); color: #2563eb; }
 .badge-info                                          { background: rgba(0,102,204,0.12);  color: var(--primary); }
 .badge-neutral                                       { background: rgba(107,114,128,0.1); color: var(--text-secondary); }
@@ -592,6 +677,7 @@ html, body {
 .health-dot.unknown   { background: var(--warning); }
 
 /* ── Modal ─────────────────────────────────────────────────── */
+.modal-backdrop,
 .modal-overlay {
     position: fixed; inset: 0;
     background: rgba(0,0,0,0.4);
@@ -599,6 +685,7 @@ html, body {
     z-index: 9000;
     animation: fadeIn 0.2s ease-out;
 }
+.modal-backdrop { padding: 16px; }
 .modal-box {
     background: var(--card-bg);
     border-radius: 12px;
@@ -615,6 +702,15 @@ html, body {
 }
 .modal-title { font-size: 18px; font-weight: 700; margin: 0; }
 .modal-close { background: none; border: none; cursor: pointer; font-size: 20px; color: var(--text-secondary); }
+
+/* ── Report callouts ───────────────────────────────────────── */
+.report-callout {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: 6px;
+    padding: 12px;
+}
 
 /* ── Wizard Steps ──────────────────────────────────────────── */
 .wizard-steps {


### PR DESCRIPTION
Dark-mode bug fixes:
- Add explicit color: var(--text-primary) to .section-card, .kpi-card, .mate-header, .mate-page so Bootstrap's --bs-body-color cannot leak through card surfaces when data-bs-theme is not set
- Fix .spinner-border colour in dark mode
- Fix TestSuites "Show Cases" expanded row: replace var(--bg-page,#f5f7fa) fallback (always-light) with var(--surface-2) + explicit text colour
- Fix Help page GitHub icon tile contrast (#24292e → #2d333b/#555f6b)
- Fix health-check pass/fail icons to use var(--success)/var(--danger)

Accent colour consistency pass:
- Home.razor: step numbers 1–4 and Quick Run icon → theme vars
- TestSuites.razor: Judge Config and AI Generation headings/callout borders → var(--secondary) / var(--success)
- Settings.razor: activity/stars/shield icon accent colours and Development Mode badge → theme vars
- Help.razor: health card borders and check/x icons → theme vars

Gradient utility classes (app.css → razor files):
- Add .icon-tile, .icon-tile-md, .icon-tile-lg base layout classes
- Add 8 solid gradient modifiers: -warning, -primary, -secondary, -info, -success, -danger, -github, -neutral-dark
- Add 5 soft (translucent) gradient modifiers: -primary-soft, -success-soft, -warning-soft, -teal-soft, -danger-soft
- Replace all 16 inline linear-gradient style attributes across Home.razor, Settings.razor, Help.razor, Agents.razor, Wizard.razor with the new utility class combinations