### PR TITLE
fix: resolve all build warnings and container script issues

### DIFF
--- a/debug-container.ps1
+++ b/debug-container.ps1
@@ -273,4 +273,4 @@ if ($Watch) {
 Write-Host "`nStreaming /app/logs from container (Ctrl+C to stop)..." -ForegroundColor Cyan
 Write-Host "Tips: -Watch (filtered events)  -DB (query results)  -Logs (raw output)" -ForegroundColor DarkGray
 Write-Host "      -Source ghcr (GHCR image)  -Source ghcr -Tag v0.3.2 (specific release)" -ForegroundColor DarkGray
-docker compose -f $activeCompose exec $serviceWebUI sh -c "tail -f /app/logs/webui-`$(date +%Y%m%d).txt 2>/dev/null || tail -f /app/logs/*.txt"
+docker compose -f $activeCompose exec $serviceWebUI sh -c "tail -f /app/logs/webui-`$(date +%Y%m%d).log 2>/dev/null || tail -f /app/logs/*.log 2>/dev/null || (echo 'No log files yet — waiting...'; sleep 5; tail -f /app/logs/*.log)"

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 # mate — local development stack
 # Usage: docker compose up -d
 # The WebUI will be available at http://localhost:5000

--- a/src/Core/mate.Data/mate.Data.csproj
+++ b/src/Core/mate.Data/mate.Data.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Host/mate.WebUI/Components/Pages/Rubrics.razor
+++ b/src/Host/mate.WebUI/Components/Pages/Rubrics.razor
@@ -383,7 +383,7 @@ else if (_formMode == "criteria" && _selectedRubricSet is not null)
             {
                 var rs = _rubricSets.First(r => r.Id == _editSetId.Value);
                 rs.Name                = _setForm.Name;
-                rs.Description         = _setForm.Description;
+                rs.Description         = _setForm.Description ?? string.Empty;
                 rs.RequireAllMandatory = _setForm.RequireAllMandatory;
                 rs.JudgeSettingId      = judgeId;
             }
@@ -395,7 +395,7 @@ else if (_formMode == "criteria" && _selectedRubricSet is not null)
                     TenantId            = TenantCtx.TenantId,
                     JudgeSettingId      = judgeId,
                     Name                = _setForm.Name,
-                    Description         = _setForm.Description,
+                    Description         = _setForm.Description ?? string.Empty,
                     RequireAllMandatory = _setForm.RequireAllMandatory,
                     CreatedAt           = DateTime.UtcNow
                 });

--- a/src/Infrastructure/mate.Infrastructure.Azure/mate.Infrastructure.Azure.csproj
+++ b/src/Infrastructure/mate.Infrastructure.Azure/mate.Infrastructure.Azure.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.14.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
   </ItemGroup>


### PR DESCRIPTION
- fix(deps): bump Azure.Messaging.ServiceBus 7.20.0 → 7.20.1 in mate.Infrastructure.Azure to resolve NU1603 (exact version unavailable)

- fix(deps): pin Microsoft.EntityFrameworkCore.Relational 9.0.2 explicitly in mate.Data to resolve MSB3277 assembly version conflict caused by Npgsql.EntityFrameworkCore.PostgreSQL pulling in 9.0.1 transitively

- fix(webui): add null-coalescing guard (via ?? string.Empty) when assigning SetForm.Description (string?) to RubricSet.Description (string) in Rubrics.razor to resolve two CS8601 warnings

- fix(docker): remove deprecated top-level 'version: "3.9"' field from infra/local/docker-compose.yml; obsolete in Docker Compose V2

- fix(scripts): correct log file glob in debug-container.ps1 from *.txt to *.log to match Serilog's rolling file output; add graceful wait when no log files exist yet on fresh container start